### PR TITLE
feat: log data as hex

### DIFF
--- a/src/govee_ble/parser.py
+++ b/src/govee_ble/parser.py
@@ -92,13 +92,15 @@ class GoveeBluetoothDeviceData(BluetoothData):
         service_uuids: list[str],
     ) -> None:
         """Parser for Govee sensors."""
-        _LOGGER.debug("Parsing Govee sensor: %s %s", mgr_id, hex(data))
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug("Parsing Govee sensor: %s %s", mgr_id, hex(data))
         msg_length = len(data)
         if msg_length > 25 and b"INTELLI_ROCKS" in data:
             # INTELLI_ROCKS sometimes ends up glued on to the end of the message
             data = data[:-25]
             msg_length = len(data)
-            _LOGGER.debug("Cleaned up packet: %s %s", mgr_id, hex(data))
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug("Cleaned up packet: %s %s", mgr_id, hex(data))
 
         if msg_length == 6 and (
             "H5072" in local_name or "H5075" in local_name or mgr_id == 0xEC88
@@ -196,7 +198,7 @@ class GoveeBluetoothDeviceData(BluetoothData):
                 )
                 self.set_device_type("H5178-REMOTE", device_id)
                 self.set_device_manufacturer("Govee", device_id)
-            else:
+            elif _LOGGER.isEnabledFor(logging.DEBUG):
                 _LOGGER.debug(
                     "Unknown sensor id for Govee H5178,"
                     " please report to the developers, data: %s",
@@ -294,11 +296,12 @@ class GoveeBluetoothDeviceData(BluetoothData):
             elif sensor_id == 2:
                 ids = [3, 4]
             else:
-                _LOGGER.debug(
-                    "Unknown sensor id: %s for a H5184, data: %s",
-                    sensor_id,
-                    hex(data),
-                )
+                if _LOGGER.isEnabledFor(logging.DEBUG):
+                    _LOGGER.debug(
+                        "Unknown sensor id: %s for a H5184, data: %s",
+                        sensor_id,
+                        hex(data),
+                    )
                 return
             self.update_temp_probe_with_alarm(
                 decode_temps_probes(temp_probe_first),

--- a/src/govee_ble/parser.py
+++ b/src/govee_ble/parser.py
@@ -53,6 +53,11 @@ def decode_temps_probes(packet_value: int) -> float:
     return float(packet_value / 100)
 
 
+def hex(data: bytes) -> str:
+    """Return a string object containing two hexadecimal digits for each byte in the instance."""
+    return "b'\\x{}'".format("\\x".join(format(b, "02x") for b in data))
+
+
 class GoveeBluetoothDeviceData(BluetoothData):
     """Data for Govee BLE sensors."""
 
@@ -87,13 +92,13 @@ class GoveeBluetoothDeviceData(BluetoothData):
         service_uuids: list[str],
     ) -> None:
         """Parser for Govee sensors."""
-        _LOGGER.debug("Parsing Govee sensor: %s %s", mgr_id, data.hex())
+        _LOGGER.debug("Parsing Govee sensor: %s %s", mgr_id, hex(data))
         msg_length = len(data)
         if msg_length > 25 and b"INTELLI_ROCKS" in data:
             # INTELLI_ROCKS sometimes ends up glued on to the end of the message
             data = data[:-25]
             msg_length = len(data)
-            _LOGGER.debug("Cleaned up packet: %s %s", mgr_id, data.hex())
+            _LOGGER.debug("Cleaned up packet: %s %s", mgr_id, hex(data))
 
         if msg_length == 6 and (
             "H5072" in local_name or "H5075" in local_name or mgr_id == 0xEC88
@@ -195,7 +200,7 @@ class GoveeBluetoothDeviceData(BluetoothData):
                 _LOGGER.debug(
                     "Unknown sensor id for Govee H5178,"
                     " please report to the developers, data: %s",
-                    data.hex(),
+                    hex(data),
                 )
             if temp >= MIN_TEMP and temp <= MAX_TEMP:
                 self.update_predefined_sensor(
@@ -290,7 +295,9 @@ class GoveeBluetoothDeviceData(BluetoothData):
                 ids = [3, 4]
             else:
                 _LOGGER.debug(
-                    "Unknown sensor id: %s for a H5184, data: %s", sensor_id, data.hex()
+                    "Unknown sensor id: %s for a H5184, data: %s",
+                    sensor_id,
+                    hex(data),
                 )
                 return
             self.update_temp_probe_with_alarm(

--- a/src/govee_ble/parser.py
+++ b/src/govee_ble/parser.py
@@ -92,14 +92,14 @@ class GoveeBluetoothDeviceData(BluetoothData):
         service_uuids: list[str],
     ) -> None:
         """Parser for Govee sensors."""
-        if _LOGGER.isEnabledFor(logging.DEBUG):
+        if debug_logging := _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug("Parsing Govee sensor: %s %s", mgr_id, hex(data))
         msg_length = len(data)
         if msg_length > 25 and b"INTELLI_ROCKS" in data:
             # INTELLI_ROCKS sometimes ends up glued on to the end of the message
             data = data[:-25]
             msg_length = len(data)
-            if _LOGGER.isEnabledFor(logging.DEBUG):
+            if debug_logging:
                 _LOGGER.debug("Cleaned up packet: %s %s", mgr_id, hex(data))
 
         if msg_length == 6 and (
@@ -198,7 +198,7 @@ class GoveeBluetoothDeviceData(BluetoothData):
                 )
                 self.set_device_type("H5178-REMOTE", device_id)
                 self.set_device_manufacturer("Govee", device_id)
-            elif _LOGGER.isEnabledFor(logging.DEBUG):
+            elif debug_logging:
                 _LOGGER.debug(
                     "Unknown sensor id for Govee H5178,"
                     " please report to the developers, data: %s",
@@ -296,7 +296,7 @@ class GoveeBluetoothDeviceData(BluetoothData):
             elif sensor_id == 2:
                 ids = [3, 4]
             else:
-                if _LOGGER.isEnabledFor(logging.DEBUG):
+                if debug_logging:
                     _LOGGER.debug(
                         "Unknown sensor id: %s for a H5184, data: %s",
                         sensor_id,

--- a/src/govee_ble/parser.py
+++ b/src/govee_ble/parser.py
@@ -55,7 +55,7 @@ def decode_temps_probes(packet_value: int) -> float:
 
 def hex(data: bytes) -> str:
     """Return a string object containing two hexadecimal digits for each byte in the instance."""
-    return "b'\\x{}'".format("\\x".join(format(b, "02x") for b in data))
+    return "b'{}'".format("".join(f"\\x{b:02x}" for b in data))
 
 
 class GoveeBluetoothDeviceData(BluetoothData):

--- a/src/govee_ble/parser.py
+++ b/src/govee_ble/parser.py
@@ -87,13 +87,13 @@ class GoveeBluetoothDeviceData(BluetoothData):
         service_uuids: list[str],
     ) -> None:
         """Parser for Govee sensors."""
-        _LOGGER.debug("Parsing Govee sensor: %s %s", mgr_id, data)
+        _LOGGER.debug("Parsing Govee sensor: %s %s", mgr_id, data.hex())
         msg_length = len(data)
         if msg_length > 25 and b"INTELLI_ROCKS" in data:
             # INTELLI_ROCKS sometimes ends up glued on to the end of the message
             data = data[:-25]
             msg_length = len(data)
-            _LOGGER.debug("Cleaned up packet: %s %s", mgr_id, data)
+            _LOGGER.debug("Cleaned up packet: %s %s", mgr_id, data.hex())
 
         if msg_length == 6 and (
             "H5072" in local_name or "H5075" in local_name or mgr_id == 0xEC88
@@ -290,7 +290,7 @@ class GoveeBluetoothDeviceData(BluetoothData):
                 ids = [3, 4]
             else:
                 _LOGGER.debug(
-                    "Unknown sensor id: %s for a H5184, data: %s", sensor_id, data
+                    "Unknown sensor id: %s for a H5184, data: %s", sensor_id, data.hex()
                 )
                 return
             self.update_temp_probe_with_alarm(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,5 @@
+import logging
+
 from bluetooth_sensor_state_data import BluetoothServiceInfo, DeviceClass, SensorUpdate
 from sensor_state_data import (
     DeviceKey,
@@ -1760,4 +1762,16 @@ def test_gvh5074():
                 native_value=-67,
             ),
         },
+    )
+
+
+def test_gvh5075_debug_hex(caplog):
+    parser = GoveeBluetoothDeviceData()
+    service_info = GVH5075_SERVICE_INFO
+    with caplog.at_level(logging.DEBUG):
+        parser.update(service_info)
+    assert (
+        "Parsing Govee sensor: 60552 b'\\x00\\x03\\x41\\xc2\\x64\\x00\\x4c\\x00\\x02\\x15\\x49\\x4e\\x54"
+        "\\x45\\x4c\\x4c\\x49\\x5f\\x52\\x4f\\x43\\x4b\\x53\\x5f\\x48\\x57\\x50\\x75\\xf2\\xff\\x0c'"
+        in caplog.text
     )


### PR DESCRIPTION
Logging binary data is quite unreadable when it contains readable characters. Always log data as hex.

`2022-12-17 10:28:48.080 DEBUG (MainThread) [govee_ble.parser] Parsing Govee sensor: 1 b'\x01\x01\x01\x802nd\x00\x03'`
becomes:
`2022-12-17 10:28:48.080 DEBUG (MainThread) [govee_ble.parser] Parsing Govee sensor: 1 b'\x01\x01\x01\x80\x32\x6e\x64\x00\x03'`
