### PR TITLE
fix: decrease minimum temperature to -30C

### DIFF
--- a/src/govee_ble/parser.py
+++ b/src/govee_ble/parser.py
@@ -29,7 +29,7 @@ PACKED_hhhhh = struct.Struct(">hhhhh")
 ERROR = "error"
 
 
-MIN_TEMP = -17.7778
+MIN_TEMP = -30
 MAX_TEMP = 100
 
 NOT_GOVEE_MANUFACTURER = {76}


### PR DESCRIPTION
Allow for temperatures as low as -11F (-24C)
Fixes https://github.com/home-assistant/core/issues/85580