### PR TITLE
feat: flag H5074 as requiring active scan

### DIFF
--- a/src/govee_ble/parser.py
+++ b/src/govee_ble/parser.py
@@ -152,9 +152,13 @@ class ModelInfo:
     sensor_type: SensorType
     button_count: int
     sleepy: bool
+    # Payload lives only in the scan response, so the device must be actively
+    # scanned long enough to capture one full broadcast cycle.
+    requires_active_scan: bool = False
 
 
 _MODEL_DB = {
+    "H5074": ModelInfo("H5074", SensorType.THERMOMETER, 0, False, True),
     "H5121": ModelInfo("H5121", SensorType.MOTION, 0, True),
     "H5122": ModelInfo("H5122", SensorType.BUTTON, 1, True),
     "H5123": ModelInfo("H5123", SensorType.WINDOW, 0, True),
@@ -225,6 +229,13 @@ class GoveeBluetoothDeviceData(BluetoothData):
         device_type = self.device_type
         assert device_type is not None
         return get_model_info(device_type).sleepy
+
+    @property
+    def requires_active_scan(self) -> bool:
+        """Return if the device must be actively scanned to read its payload."""
+        device_type = self.device_type
+        assert device_type is not None
+        return get_model_info(device_type).requires_active_scan
 
     def _process_mfr_data(
         self,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1037,6 +1037,12 @@ def test_can_create():
     GoveeBluetoothDeviceData()
 
 
+def test_get_model_info_requires_active_scan():
+    assert get_model_info("H5074").requires_active_scan is True
+    assert get_model_info("H5075").requires_active_scan is False
+    assert get_model_info("H5179").requires_active_scan is False
+
+
 def test_gvh5051():
     parser = GoveeBluetoothDeviceData()
     service_info = GVH5051_SERVICE_INFO
@@ -1577,6 +1583,7 @@ def test_gvh5074():
     service_info = GVH5074_SERVICE_INFO
     result = parser.update(service_info)
     assert parser.sleepy is False
+    assert parser.requires_active_scan is True
     assert result == SensorUpdate(
         title=None,
         devices={
@@ -1639,6 +1646,7 @@ def test_gvh5075():
     parser = GoveeBluetoothDeviceData()
     service_info = GVH5075_SERVICE_INFO
     result = parser.update(service_info)
+    assert parser.requires_active_scan is False
     assert result == SensorUpdate(
         title=None,
         devices={


### PR DESCRIPTION
The H5074 only carries its temperature and humidity in the scan response, so a short active scan window misses it most cycles; the H5075 broadcasts the payload in the primary advert and is fine.

This adds requires_active_scan to ModelInfo, set for the H5074, so consumers can request a longer active scan window for these scan response only models.

See home-assistant/core#174507.