### PR TITLE
feat: detect H5129 and require active scans for H5075 and H5129

### DIFF
--- a/src/govee_ble/parser.py
+++ b/src/govee_ble/parser.py
@@ -152,32 +152,40 @@ class ModelInfo:
     """Model information for Govee sensors."""
 
     model_id: str
-    sensor_type: SensorType
-    button_count: int
-    sleepy: bool
+    sensor_type: SensorType = SensorType.THERMOMETER
+    button_count: int = 0
+    sleepy: bool = False
     # Payload lives only in the scan response, so the device must be actively
     # scanned long enough to capture one full broadcast cycle.
     requires_active_scan: bool = False
 
 
 _MODEL_DB = {
-    "H5074": ModelInfo("H5074", SensorType.THERMOMETER, 0, False, True),
-    "H5121": ModelInfo("H5121", SensorType.MOTION, 0, True),
-    "H5122": ModelInfo("H5122", SensorType.BUTTON, 1, True),
-    "H5123": ModelInfo("H5123", SensorType.WINDOW, 0, True),
-    "H5124": ModelInfo("H5124", SensorType.VIBRATION, 0, True),
-    "H5125": ModelInfo("H5125", SensorType.BUTTON, 6, True),
-    "H5126": ModelInfo("H5126", SensorType.BUTTON, 2, True),
-    "H5127": ModelInfo("H5127", SensorType.PRESENCE, 0, True),
-    "H5130": ModelInfo("H5130", SensorType.PRESSURE, 1, True),
+    "H5074": ModelInfo("H5074", requires_active_scan=True),
+    "H5075": ModelInfo("H5075", requires_active_scan=True),
+    "H5129": ModelInfo("H5129", requires_active_scan=True),
+    "H5121": ModelInfo("H5121", sensor_type=SensorType.MOTION, sleepy=True),
+    "H5122": ModelInfo(
+        "H5122", sensor_type=SensorType.BUTTON, button_count=1, sleepy=True
+    ),
+    "H5123": ModelInfo("H5123", sensor_type=SensorType.WINDOW, sleepy=True),
+    "H5124": ModelInfo("H5124", sensor_type=SensorType.VIBRATION, sleepy=True),
+    "H5125": ModelInfo(
+        "H5125", sensor_type=SensorType.BUTTON, button_count=6, sleepy=True
+    ),
+    "H5126": ModelInfo(
+        "H5126", sensor_type=SensorType.BUTTON, button_count=2, sleepy=True
+    ),
+    "H5127": ModelInfo("H5127", sensor_type=SensorType.PRESENCE, sleepy=True),
+    "H5130": ModelInfo(
+        "H5130", sensor_type=SensorType.PRESSURE, button_count=1, sleepy=True
+    ),
 }
 
 
 def get_model_info(model_id: str) -> ModelInfo:
     """Get model information for a Govee sensor."""
-    return _MODEL_DB.get(
-        model_id, ModelInfo(model_id, SensorType.THERMOMETER, 0, False)
-    )
+    return _MODEL_DB.get(model_id, ModelInfo(model_id))
 
 
 class GoveeBluetoothDeviceData(BluetoothData):
@@ -375,12 +383,15 @@ class GoveeBluetoothDeviceData(BluetoothData):
         if msg_length == 6 and (
             (is_5072 := "H5072" in local_name)
             or (is_5075 := "H5075" in local_name)
+            or (is_5129 := "H5129" in local_name)
             or mgr_id == 0xEC88
         ):
             if is_5072:
                 self.set_device_type("H5072")
             elif is_5075:
                 self.set_device_type("H5075")
+            elif is_5129:
+                self.set_device_type("H5129")
             else:
                 self.set_device_type("H5072/H5075")
             temp, humi, batt, err = decode_temp_humid_battery_error(data[1:5])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -229,6 +229,18 @@ GVH5072_75_GENERIC_SERVICE_INFO = BluetoothServiceInfo(
 )
 
 
+# Shares the H5075 6-byte EC88 payload but identifies itself as an H5129.
+GVH5129_SERVICE_INFO = BluetoothServiceInfo(
+    name="GVH5129_ABCD",
+    address="61DE521B-F0BF-9F44-64D4-75BBE1738105",
+    rssi=-63,
+    manufacturer_data={60552: b"\x00\x03M\xb2d\x00"},
+    service_uuids=["0000ec88-0000-1000-8000-00805f9b34fb"],
+    service_data={},
+    source="local",
+)
+
+
 GVH5100_SERVICE_INFO = BluetoothServiceInfo(
     name="GVH5100_7738",
     address="C4:35:33:33:77:38",
@@ -1197,7 +1209,10 @@ def test_can_create():
 
 def test_get_model_info_requires_active_scan():
     assert get_model_info("H5074").requires_active_scan is True
-    assert get_model_info("H5075").requires_active_scan is False
+    assert get_model_info("H5075").requires_active_scan is True
+    assert get_model_info("H5129").requires_active_scan is True
+    assert get_model_info("H5072/H5075").requires_active_scan is False
+    assert get_model_info("H5072").requires_active_scan is False
     assert get_model_info("H5179").requires_active_scan is False
 
 
@@ -1872,7 +1887,7 @@ def test_gvh5075():
     parser = GoveeBluetoothDeviceData()
     service_info = GVH5075_SERVICE_INFO
     result = parser.update(service_info)
-    assert parser.requires_active_scan is False
+    assert parser.requires_active_scan is True
     assert result == SensorUpdate(
         title=None,
         devices={
@@ -1950,6 +1965,20 @@ def test_gvh5072_75_generic_by_mfr_id():
     parser = GoveeBluetoothDeviceData()
     result = parser.update(GVH5072_75_GENERIC_SERVICE_INFO)
     assert parser.device_type == "H5072/H5075"
+    temp_key = DeviceKey(key="temperature", device_id=None)
+    humi_key = DeviceKey(key="humidity", device_id=None)
+    batt_key = DeviceKey(key="battery", device_id=None)
+    assert result.entity_values[temp_key].native_value == 21.6
+    assert result.entity_values[humi_key].native_value == 49.8
+    assert result.entity_values[batt_key].native_value == 100
+
+
+def test_gvh5129():
+    """An H5129 shares the H5075 payload but registers as its own model."""
+    parser = GoveeBluetoothDeviceData()
+    result = parser.update(GVH5129_SERVICE_INFO)
+    assert parser.device_type == "H5129"
+    assert parser.requires_active_scan is True
     temp_key = DeviceKey(key="temperature", device_id=None)
     humi_key = DeviceKey(key="humidity", device_id=None)
     batt_key = DeviceKey(key="battery", device_id=None)


### PR DESCRIPTION
The H5075 and H5129 carry their measurements in the scan response, so they need active scans like the H5074; this flags requires_active_scan for both.

The H5129 now has its own detection branch by name instead of falling through to the shared H5072/H5075 device type. The H5072/H5075 fallback stays passive since reaching it means we already received the payload passively.

ModelInfo fields gain defaults so each entry only specifies what differs.